### PR TITLE
Fix load error on require 'narray-devel' by adding lib/narray-devel.rb

### DIFF
--- a/lib/narray-devel.rb
+++ b/lib/narray-devel.rb
@@ -1,0 +1,1 @@
+require 'narray'


### PR DESCRIPTION
Added ```lib/narray-devel.rb``` which contains just a simple ```require 'narray'```.

This allows you to ```require 'narray-devel'``` successfully without LoadError (currently, you have to do ```gem 'narray-devel'; require 'narray'```